### PR TITLE
Bump serialize-javascript to >=3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "next": "9.3.5",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.3",
+    "serialize-javascript": ">=3.1.0"
   }
 }


### PR DESCRIPTION
serialize-javascript prior to 3.1.0 allows remote attackers to inject arbitrary code via the function "deleteFunctions" within "index.js"